### PR TITLE
Fix connection issue over basic authentication

### DIFF
--- a/app/__tests__/options.test.js
+++ b/app/__tests__/options.test.js
@@ -218,40 +218,6 @@ describe("options without config", () => {
       geti18nMessage("optionsMessageMissingConfig")
     );
   });
-
-  /* ------------------------------------------------------------------------ */
-
-  test("save credentials with wrong email", async () => {
-    render(<Options />);
-
-    // Get components from DOM
-    const endpoint = screen
-      .getByTestId("input-endpoint")
-      .querySelector("input");
-    const email = screen.getByTestId("input-email").querySelector("input");
-    const password = screen
-      .getByTestId("input-password")
-      .querySelector("input");
-
-    // Simulate a click on "credentials" accordion
-    userEvent.click(screen.getByTestId("credentials"));
-
-    // Simulate a user event typing endpoing, wrong email address and HTTP password
-    userEvent.type(endpoint, "https://hereweare.testing.it");
-    userEvent.type(email, "baby.shark");
-    userEvent.type(password, "dododo");
-
-    // Simulate a click on "credentials" accordion
-    userEvent.click(screen.getByLabelText("save-config"));
-
-    // Wait until snackbar appears with some status message
-    await waitFor(() => screen.getByLabelText("snackbar"));
-
-    // Check status message
-    expect(screen.getByLabelText("snackbar")).toHaveTextContent(
-      geti18nMessage("optionsMessageInvalidEmail")
-    );
-  });
 });
 
 /* -------------------------------------------------------------------------- */

--- a/app/__tests__/utils.js
+++ b/app/__tests__/utils.js
@@ -123,9 +123,7 @@ export function mockPopupState(opened) {
 export function mockResolvedAxiosGetOnce(url, options, result) {
   when(axios.get)
     .calledWith(
-      url,
-      {},
-      {
+      url, {
         auth: {
           username: options.credentials.email,
           password: options.credentials.password,
@@ -138,9 +136,7 @@ export function mockResolvedAxiosGetOnce(url, options, result) {
 export function mockRejectedAxiosGetOnce(url, options, result) {
   when(axios.get)
     .calledWith(
-      url,
-      {},
-      {
+      url, {
         auth: {
           username: options.credentials.email,
           password: options.credentials.password,

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -36,7 +36,7 @@
     "description": "The title of the gerrit credential configuration"
   },
   "optionsGerritEmail": {
-    "message": "Email address",
+    "message": "Email address or username",
     "description": "The title of the gerrit credential configuration for e-mail"
   },
   "optionsGerritPassword": {
@@ -58,10 +58,6 @@
   "optionsMessageMissingConfig": {
     "message": "Gerrit configuration is missing...",
     "description": "The title of the gerrit message for missing configuration"
-  },
-  "optionsMessageInvalidEmail": {
-    "message": "Email address is not valid",
-    "description": "The title of the gerrit message for wrong email address"
   },
   "optionsMessageTestSuccess": {
     "message": "Gerrit API is working just fine!",

--- a/app/scripts/components/background/gerrit.js
+++ b/app/scripts/components/background/gerrit.js
@@ -13,9 +13,7 @@ const gerrit = {
     try {
       data = await axios
         .get(
-          url,
-          {},
-          {
+          url, {
             auth: {
               username: options.credentials.email,
               password: options.credentials.password,
@@ -50,9 +48,7 @@ const gerrit = {
     try {
       result = await axios
         .get(
-          url,
-          {},
-          {
+          url, {
             auth: {
               username: credentials.email,
               password: credentials.password,

--- a/app/scripts/components/options/options.jsx
+++ b/app/scripts/components/options/options.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 
 import { isEmpty } from "lodash";
-import { isEmail } from "validator";
 
 import Grid from "@material-ui/core/Grid";
 
@@ -52,8 +51,6 @@ function Options() {
     let dummy = "";
     if (endpoint == "") {
       dummy = browser.i18n.getMessage("optionsMessageMissingConfig");
-    } else if (!isEmail(credentials.email)) {
-      dummy = browser.i18n.getMessage("optionsMessageInvalidEmail");
     } else {
       // Save new config in storage
       const data = { refreshTime, endpoint, credentials };


### PR DESCRIPTION
I made two changes:

1. Remove email address control. Some clients relies on basic authentication over username instead of email address.
2. Update axios callers. Axios http callers does not add properly basic authentication information to the headers.

I successfully make query our gerrit instance after the changes.
<img width="469" alt="CleanShot 2024-04-14 at 08 15 00@2x" src="https://github.com/v1nns/yang/assets/10091984/7aaf9dcd-71bf-4176-a08e-117eaecd3915">